### PR TITLE
Update the package information in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Ripple Network overcomes the limitations of existing embedding-based and path-ba
 
 ### Required packages
 The code has been tested running under Python 3.6.5, with the following packages installed (along with their dependencies):
-- tensorflow-gpu == 1.4.0
-- numpy == 1.14.5
-- sklearn == 0.19.1
+- tensorflow == 1.8.0
+- numpy == 1.15.1
+- scikit-learn == 0.19.2
+- scipy == 1.1.0
 
 
 ### Running the code


### PR DESCRIPTION
- add scipy to the dependencies
- refer to scikit-learn with its PyPI name
- update the package versions